### PR TITLE
GC-1: Fix support for lambdas

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -19,6 +19,7 @@ buildscript {
         mavenLocal()
         mavenCentral()
         jcenter()
+        google()
     }
     dependencies {
         classpath ANDROID_GRADLE_PLUGIN
@@ -33,5 +34,6 @@ allprojects {
         mavenLocal()
         mavenCentral()
         jcenter()
+        google()
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -17,8 +17,8 @@
 # When updating the version name, also update it in:
 # - GroundControlPlugin.java (in the plugin module).
 # - README.md
-VERSION_NAME=1.0.0
-VERSION_CODE=6
+VERSION_NAME=1.0.1-SNAPSHOT
+VERSION_CODE=7
 
 # Dependencies.
 
@@ -30,10 +30,9 @@ SUPPORT_LIB_VERSION=25.3.1
 
 BUILD_TOOLS_VERSION=27.0.3
 
-ANDROID_GRADLE_PLUGIN=com.android.tools.build:gradle:2.2.2
+ANDROID_GRADLE_PLUGIN=com.android.tools.build:gradle:3.1.2
 GRADLE_NEXUS_PLUGIN=com.bmuschko:gradle-nexus-plugin:2.3.1
 MAVEN_GRADLE_PLUGIN=com.github.dcendents:android-maven-gradle-plugin:1.4.1
-RETROLAMBDA=me.tatarka:gradle-retrolambda:3.7.0
 
 # When updating version for the AspectJ runtime, also update it in GroundControlPlugin.groovy
 # (in groundcontrol-plugin module).

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -19,4 +19,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.4-all.zip

--- a/groundcontrol/build.gradle
+++ b/groundcontrol/build.gradle
@@ -39,7 +39,7 @@ android {
 }
 
 dependencies {
-    provided "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
+    compileOnly "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
 }
 
 apply from: rootProject.file('distribution.gradle')

--- a/plugin/build.gradle
+++ b/plugin/build.gradle
@@ -21,9 +21,8 @@ targetCompatibility = JavaVersion.VERSION_1_7
 sourceCompatibility = JavaVersion.VERSION_1_7
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile ANDROID_GRADLE_PLUGIN
+    compileOnly gradleApi()
+    compileOnly ANDROID_GRADLE_PLUGIN
     compile ASPECTJ_TOOLS
     compile ASPECTJ_RUNTIME
 }

--- a/plugin/src/main/java/com/fjordnet/groundcontrol/gradle/GroundControlPlugin.java
+++ b/plugin/src/main/java/com/fjordnet/groundcontrol/gradle/GroundControlPlugin.java
@@ -36,7 +36,7 @@ import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.artifacts.dsl.RepositoryHandler;
 import org.gradle.api.logging.Logger;
 import org.gradle.api.plugins.PluginContainer;
-import org.gradle.api.tasks.compile.AbstractCompile;
+import org.gradle.api.tasks.compile.JavaCompile;
 
 import java.io.File;
 import java.util.Iterator;
@@ -52,7 +52,7 @@ import static org.aspectj.bridge.IMessage.WARNING;
  */
 public class GroundControlPlugin implements Plugin<Project> {
 
-    private static final String GROUND_CONTROL_VERSION = "1.0.0";
+    private static final String GROUND_CONTROL_VERSION = "1.0.1-SNAPSHOT";
     private static final String ASPECTJ_RUNTIME_VERSION = "1.8.9";
 
     private static final String APT = "annotationProcessor";
@@ -137,11 +137,11 @@ public class GroundControlPlugin implements Plugin<Project> {
 
     private static class AjcAction implements Action<Task> {
 
-        private AbstractCompile compiler;
+        private JavaCompile compiler;
         private BaseExtension android;
         private Logger logger;
 
-        public AjcAction(AbstractCompile compiler, BaseExtension android, Logger logger) {
+        public AjcAction(JavaCompile compiler, BaseExtension android, Logger logger) {
             this.compiler = compiler;
             this.android = android;
             this.logger = logger;
@@ -157,7 +157,7 @@ public class GroundControlPlugin implements Plugin<Project> {
             String destinationDir = compiler.getDestinationDir().toString();
             String inpath = destinationDir;
             String classpath = compiler.getClasspath().getAsPath();
-            String bootClasspath = join(android.getBootClasspath());
+            String bootClasspath = compiler.getOptions().getBootstrapClasspath().getAsPath();
 
             String[] args = {
                     "-showWeaveInfo",

--- a/sample/build.gradle
+++ b/sample/build.gradle
@@ -19,16 +19,15 @@ buildscript {
         mavenLocal()
         mavenCentral()
         jcenter()
+        google()
     }
     dependencies {
         classpath "com.fjordnet.groundcontrol:gradle-plugin:$VERSION_NAME"
-        classpath RETROLAMBDA
     }
 }
 
 apply plugin: 'com.android.application'
 apply plugin: 'com.fjordnet.groundcontrol'
-apply plugin: 'me.tatarka.retrolambda'
 
 android {
     compileOptions {
@@ -55,10 +54,6 @@ android {
     }
 }
 
-retrolambda {
-    jvmArgs '-noverify'
-}
-
 repositories {
     mavenLocal()
     maven { url 'https://oss.sonatype.org/content/groups/staging' }
@@ -67,8 +62,8 @@ repositories {
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
-    compile "com.android.support:design:$SUPPORT_LIB_VERSION"
-    compile CONSTRAINT_LAYOUT
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:$SUPPORT_LIB_VERSION"
+    implementation "com.android.support:design:$SUPPORT_LIB_VERSION"
+    implementation CONSTRAINT_LAYOUT
 }


### PR DESCRIPTION
- Modified the Ground Control plugin implementation
to supply to ajc the Java boot classpath instead of the
Android one.
- This is because desugaring classes such as
LambdaMetafactory are removed from the Android boot
classpath during the gradle build.
- Removed Retrolambda from the sample project in favor
of using native lambdas.
- Updated the version name to 1.0.1-SNAPSHOT.
- Updated versions for gradle and the Android gradle plugin.